### PR TITLE
Support distributed encoding

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.rs]
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+
+[[package]]
+name = "base64"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
+
+[[package]]
+name = "bcrypt"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b70db86f3c560199b0dada79a22b9a924622384abb2a756a9707ffcce077f2"
+dependencies = [
+ "base64 0.12.1",
+ "blowfish",
+ "byteorder",
+ "getrandom",
+]
+
+[[package]]
+name = "bincode"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
+dependencies = [
+ "byteorder",
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,10 +130,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "614aa3f2bac03707e62a84d18a48dd3d9ea6171313fd5e6a53b5054d8ae74601"
 
 [[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array",
+]
+
+[[package]]
+name = "block-cipher-trait"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeb80d00f2688459b8542068abd974cfb101e7a82182414a99b5026c0d85cc3"
+dependencies = [
+ "block-cipher-trait",
+ "byteorder",
+ "opaque-debug",
+]
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
+name = "bytes"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 
 [[package]]
 name = "bytesize"
@@ -164,6 +251,22 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "crossbeam-channel"
@@ -234,6 +337,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +371,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +418,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,12 +433,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+
+[[package]]
 name = "humantime"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -297,6 +479,15 @@ dependencies = [
  "lazy_static",
  "number_prefix",
  "regex",
+]
+
+[[package]]
+name = "input_buffer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -318,6 +509,12 @@ checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "ivf"
@@ -359,6 +556,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +598,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea4fa2ba8f650120445ddcf137d8a6370ff01d55f00e6b29e0ab01b7c846464"
 dependencies = [
  "rayon",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -459,6 +680,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "openssl"
+version = "0.10.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02309a7f127000ed50594f0b50ecc69e7c654e16d41b4e8156d1b3df8e0b52e"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "paste"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +739,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "ppv-lite86"
@@ -560,7 +832,7 @@ dependencies = [
 [[package]]
 name = "rav1e"
 version = "0.3.0"
-source = "git+https://github.com/xiph/rav1e#dfc0e67eb1e4218136e47cc651463e8c00ca8c99"
+source = "git+https://github.com/xiph/rav1e#0be21f39a0c7d61c4c5b5b660959bea2894bb42c"
 dependencies = [
  "arbitrary",
  "arg_enum_proc_macro",
@@ -582,8 +854,10 @@ dependencies = [
  "rayon",
  "regex",
  "rustc_version",
+ "serde",
  "simd_helpers",
  "thiserror",
+ "toml",
  "v_frame",
  "vergen",
 ]
@@ -595,12 +869,14 @@ dependencies = [
  "anyhow",
  "arrayvec",
  "av-scenechange",
+ "bincode",
  "clap",
  "console",
  "crossbeam-channel",
  "crossbeam-utils",
  "dialoguer",
  "env_logger",
+ "http",
  "indicatif",
  "itertools",
  "ivf",
@@ -612,8 +888,13 @@ dependencies = [
  "systemstat",
  "thiserror",
  "threadpool",
+ "toml",
+ "tungstenite",
+ "url",
+ "uuid",
  "v_frame",
  "y4m 0.6.0",
+ "zstd",
 ]
 
 [[package]]
@@ -621,13 +902,28 @@ name = "rav1e-worker"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bcrypt",
+ "bincode",
+ "chrono",
  "clap",
- "ivf",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "env_logger",
+ "http",
+ "itertools",
+ "lazy_static",
+ "log",
+ "native-tls",
  "num_cpus",
+ "rav1e",
  "rav1e-by-gop",
  "rmp-serde",
  "serde",
+ "threadpool",
+ "tungstenite",
+ "uuid",
  "v_frame",
+ "zstd",
 ]
 
 [[package]]
@@ -718,10 +1014,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -759,6 +1088,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +1107,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "strsim"
@@ -900,6 +1247,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
+dependencies = [
+ "base64 0.11.0",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "input_buffer",
+ "log",
+ "native-tls",
+ "rand",
+ "sha-1",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,15 +1312,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
+name = "url"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+dependencies = [
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand",
+ "serde",
+]
+
+[[package]]
 name = "v_frame"
 version = "0.1.0"
-source = "git+https://github.com/xiph/rav1e#dfc0e67eb1e4218136e47cc651463e8c00ca8c99"
+source = "git+https://github.com/xiph/rav1e#0be21f39a0c7d61c4c5b5b660959bea2894bb42c"
 dependencies = [
  "cfg-if",
  "noop_proc_macro",
  "num-derive",
  "num-traits",
+ "serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
 name = "vec_map"
@@ -931,7 +1365,7 @@ checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 [[package]]
 name = "vergen"
 version = "3.0.4"
-source = "git+https://github.com/xiph/rav1e#dfc0e67eb1e4218136e47cc651463e8c00ca8c99"
+source = "git+https://github.com/xiph/rav1e#0be21f39a0c7d61c4c5b5b660959bea2894bb42c"
 dependencies = [
  "bitflags",
  "chrono",
@@ -985,3 +1419,33 @@ name = "y4m"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5dbad859ce2d3ef045f80c0e55653d6ab8bdc4f3705bbb0a69c3282316697c5"
+
+[[package]]
+name = "zstd"
+version = "0.5.1+zstd.1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5d978b793ae64375b80baf652919b148f6a496ac8802922d9999f5a553194f"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "2.0.3+zstd.1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee25eac9753cfedd48133fa1736cbd23b774e253d89badbeac7d12b23848d3f"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "1.4.15+zstd.1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89719b034dc22d240d5b407fb0a3fe6d29952c181cff9a9f95c0bd40b4f8f7d8"
+dependencies = [
+ "cc",
+ "glob",
+ "libc",
+]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,49 @@ By default, the rav1e-by-gop client can run on a single machine.
 However, it can be set up to take advantage of remote machines
 running the rav1e worker for distributed encoding.
 
-TODO: Usage details
+### Server setup
+
+rav1e-worker runs a server that listens for connections from rav1e-by-gop,
+then uses worker threads to encode segments for the remote machines.
+
+By default, rav1e-worker will accept insecure connections,
+because unfortunately self-signed certs will not work.
+
+You can configure rav1e-worker to use secure TLS connections.
+If you have a signed TLS certificate you would like to use,
+or would like to get one for free from Let's Encrypt,
+you can create an identity file for rav1e-worker to read
+with the following command:
+
+```
+openssl pkcs12 -export -out identity.p12 -inkey /etc/letsencrypt/live/mydomain.example/privkey.pem -in /etc/letsencrypt/live/mydomain.example/cert.pem -certfile /etc/letsencrypt/live/mydomain.example/chain.pem
+```
+
+You can tell rav1e-worker to accept TLS connections by
+by setting the path to the identity file
+in the `IDENTITY_FILE` environment variable.
+If your identity file has a password, you can set the password
+via the `IDENTITY_PASSWORD` environment variable. By default,
+a passwordless identity file is assumed.
+
+You must also create a password for clients to use to connect to the server.
+This is mandatory. You should set this password to the `SERVER_PASSWORD` environment variable.
+It is highly recommended to use a secure password generator like [this one](https://correcthorsebatterystaple.net/).
+
+You can then run `rav1e-worker`, which will listen by default on port 13415,
+and spawn workers up to the number of logical CPU cores.
+You can configure which IP and port to listen on as well as how many workers
+to spawn via CLI args to rav1e-worker.
+
+### Client setup
+
+You can tell rav1e-by-gop to connect to remote workers by using a `workers.toml` file.
+There is an example of this file in this repository.
+By default, the client will look in the current working directory for the file.
+You can override it by using the `--workers /path/to/workers.toml` CLI flag.
+
+rav1e-by-gop will by default use the local worker threads as well.
+You can disable local encoding entirely with the `--no-local` flag.
 
 ## Limitations
 

--- a/rav1e-by-gop/Cargo.toml
+++ b/rav1e-by-gop/Cargo.toml
@@ -12,25 +12,32 @@ autobins = false
 anyhow = "1.0"
 arrayvec = "0.5"
 av-scenechange = { version = "0.4", default-features = false, features = [ "serde" ], optional = true }
+bincode = "1.2"
 clap = { version = "2", optional = true }
 console = { version = "0.11.3", optional = true }
 crossbeam-channel = "0.4"
-crossbeam-utils = "0.7"
+crossbeam-utils = { version = "0.7", optional = true }
 dialoguer = { version = "0.6", optional = true }
 env_logger = { version = "0.7.1", optional = true }
+http = { version = "0.2", optional = true }
 indicatif = { version = "0.14", optional = true }
-itertools = "0.9"
+itertools = { version = "0.9", optional = true }
 ivf = "0.1"
 log = "0.4"
 num_cpus = { version = "1", optional = true }
-rav1e = { git = "https://github.com/xiph/rav1e", default-features = false, features = [ "asm" ] }
+rav1e = { git = "https://github.com/xiph/rav1e", default-features = false, features = ["asm", "serialize"] }
 rmp-serde = { version = "0.14", optional = true }
 serde = { version = "1", features = ["derive"] }
-systemstat = { version = "0.1", optional = true }
-thiserror = "1"
+systemstat = "0.1"
+thiserror = { version = "1", optional = true }
 threadpool = "1"
-v_frame = "0.1"
+toml = { version = "0.5", optional = true }
+tungstenite = "0.10"
+url = { version = "2.1", optional = true }
+uuid = { version = "0.8", features = ["serde"] }
+v_frame = { version = "0.1", features = ["serialize"] }
 y4m = { version = "0.6", optional = true }
+zstd = "0.5"
 
 [[bin]]
 name = "rav1e-by-gop"
@@ -43,11 +50,16 @@ binary = [
     "av-scenechange",
     "clap",
     "console",
+    "crossbeam-utils",
     "dialoguer",
     "env_logger",
+    "http",
     "indicatif",
+    "itertools",
     "num_cpus",
     "rmp-serde",
-    "systemstat",
+    "thiserror",
+    "toml",
+    "url",
     "y4m"
 ]

--- a/rav1e-by-gop/src/bin/encode.rs
+++ b/rav1e-by-gop/src/bin/encode.rs
@@ -1,17 +1,23 @@
 use super::VideoDetails;
-use crate::analyze::{run_first_pass, AnalyzerChannel, InputFinishedChannel};
+use crate::analyze::{
+    run_first_pass, AnalyzerChannel, AnalyzerReceiver, InputFinishedChannel, InputFinishedReceiver,
+    RemoteAnalyzerChannel, RemoteAnalyzerReceiver,
+};
 use crate::decide_thread_count;
 use crate::decode::*;
 use crate::muxer::create_muxer;
 use crate::progress::*;
+use crate::remote::{discover_remote_worker, remote_encode_segment, RemoteWorkerInfo};
 use crate::CliOptions;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use console::style;
 use crossbeam_channel::{bounded, unbounded, TryRecvError};
 use crossbeam_utils::thread::{scope, Scope};
-use log::info;
+use log::{debug, error, info};
 use rav1e::prelude::*;
 use rav1e_by_gop::*;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use std::collections::BTreeSet;
 use std::fs::remove_file;
 use std::fs::File;
@@ -59,7 +65,10 @@ pub fn perform_encode(
     .unwrap()
 }
 
-pub fn perform_encode_inner<T: Pixel, R: 'static + Read + Send>(
+pub fn perform_encode_inner<
+    T: Pixel + Serialize + DeserializeOwned + Default,
+    R: 'static + Read + Send,
+>(
     s: &Scope,
     keyframes: BTreeSet<usize>,
     next_analysis_frame: usize,
@@ -82,9 +91,42 @@ pub fn perform_encode_inner<T: Pixel, R: 'static + Read + Send>(
     );
 
     let num_threads = decide_thread_count(opts, &video_info);
-    let mut thread_pool = ThreadPool::new(num_threads);
-    info!("Using {} encoder threads", style(num_threads).cyan());
+    if num_threads > 0 {
+        info!("Using {} encoder threads", style(num_threads).cyan());
+    }
 
+    let remote_workers = opts
+        .workers
+        .iter()
+        .map(|worker| discover_remote_worker(worker))
+        .filter_map(|worker| {
+            worker
+                .map_err(|e| {
+                    error!("Failed to negotiate with remote worker: {}", e);
+                    e
+                })
+                .ok()
+        })
+        .collect::<Vec<_>>();
+    let worker_thread_count = remote_workers
+        .iter()
+        .map(|worker| worker.workers.len())
+        .sum::<usize>();
+    if !remote_workers.is_empty() {
+        info!(
+            "Discovered {} remote workers with up to {} slots",
+            remote_workers.len(),
+            worker_thread_count
+        )
+    } else if num_threads == 0 {
+        bail!("Cannot disable local threads without having remote workers available!");
+    }
+
+    let mut thread_pool = if num_threads > 0 {
+        Some(ThreadPool::new(num_threads))
+    } else {
+        None
+    };
     let overall_progress = if let Some(progress) = progress {
         progress
     } else {
@@ -107,9 +149,13 @@ pub fn perform_encode_inner<T: Pixel, R: 'static + Read + Send>(
     };
 
     let analyzer_channel: AnalyzerChannel<T> = unbounded();
-    let progress_channels: Vec<ProgressChannel> = (0..num_threads).map(|_| unbounded()).collect();
+    let remote_analyzer_channel: RemoteAnalyzerChannel = unbounded();
+    let progress_channels: Vec<ProgressChannel> = (0..(num_threads + worker_thread_count))
+        .map(|_| unbounded())
+        .collect();
     let input_finished_channel: InputFinishedChannel = bounded(1);
     let slots: Arc<Mutex<Vec<bool>>> = Arc::new(Mutex::new(vec![false; num_threads]));
+    let remote_slots = Arc::new(Mutex::new(remote_workers));
 
     let output_file = opts.output.to_owned();
     let verbose = opts.verbose;
@@ -123,11 +169,13 @@ pub fn perform_encode_inner<T: Pixel, R: 'static + Read + Send>(
         .map(|(_, rx)| rx.clone())
         .collect::<Vec<_>>();
     let slots_ref = slots.clone();
+    let remote_slots_ref = remote_slots.clone();
     let input_finished_receiver = input_finished_channel.1.clone();
     s.spawn(move |_| {
         watch_progress_receivers(
             receivers,
             slots_ref,
+            remote_slots_ref,
             output_file,
             verbose,
             overall_progress,
@@ -138,18 +186,45 @@ pub fn perform_encode_inner<T: Pixel, R: 'static + Read + Send>(
 
     let opts_ref = opts.clone();
     let analyzer_sender = analyzer_channel.0.clone();
-    s.spawn(move |_| {
+    let remote_analyzer_sender = remote_analyzer_channel.0.clone();
+    let remote_slots_ref = remote_slots.clone();
+    let input_finished_sender = input_finished_channel.0.clone();
+    let input_finished_receiver = input_finished_channel.1.clone();
+    let progress_senders = progress_channels
+        .iter()
+        .map(|(tx, _)| tx.clone())
+        .collect::<Vec<_>>();
+    let remote_progress_senders = progress_senders
+        .iter()
+        .skip(num_threads)
+        .cloned()
+        .collect::<Vec<_>>();
+    s.spawn(move |s| {
         run_first_pass(
             dec,
             opts_ref,
             analyzer_sender,
+            remote_analyzer_sender,
+            progress_senders,
+            remote_progress_senders,
+            input_finished_sender,
+            input_finished_receiver,
             slots,
+            remote_slots_ref,
             start_frameno,
             known_keyframes,
             skipped_segments,
-        )
-        .expect("An error occurred during input analysis");
+            video_info,
+            s,
+        );
     });
+
+    for worker in remote_slots.lock().unwrap().iter() {
+        let receiver = worker.update_channel.1.clone();
+        let remote_slots_ref = remote_slots.clone();
+        let input_finished_receiver = input_finished_channel.1.clone();
+        s.spawn(move |_| watch_worker_updates(remote_slots_ref, receiver, input_finished_receiver));
+    }
 
     // Write only the ivf header
     create_muxer(&get_segment_output_filename(&opts.output, 0))
@@ -163,42 +238,171 @@ pub fn perform_encode_inner<T: Pixel, R: 'static + Read + Send>(
         })
         .expect("Failed to create segment output");
 
+    let input_finished_receiver = input_finished_channel.1;
+    let remote_analyzer_receiver = remote_analyzer_channel.1;
+    let remote_slots_ref = remote_slots;
+    let remote_listener = s.spawn(move |s| {
+        listen_for_remote_workers(
+            s,
+            remote_analyzer_receiver,
+            input_finished_receiver,
+            remote_slots_ref,
+        )
+    });
+
     let mut num_segments = 0;
-    let encode_opts = EncodeOptions::from(opts);
-    let output_file = opts.output.to_owned();
+    if num_threads > 0 {
+        let _ = listen_for_local_workers(
+            EncodeOptions::from(opts),
+            &opts.output,
+            &mut num_segments,
+            thread_pool.as_mut().unwrap(),
+            video_info,
+            &progress_channels,
+            analyzer_channel.1,
+        );
+        thread_pool.unwrap().join();
+    }
+    let _ = remote_listener.join();
+
+    mux_output_files(&opts.output, num_segments)?;
+
+    Ok(())
+}
+
+fn watch_worker_updates(
+    remote_slots: Arc<Mutex<Vec<RemoteWorkerInfo>>>,
+    update_receiver: WorkerUpdateReceiver,
+    input_finished_receiver: InputFinishedReceiver,
+) {
+    let mut done = false;
     loop {
-        match analyzer_channel.1.try_recv() {
+        sleep(Duration::from_millis(100));
+
+        if !done && input_finished_receiver.is_full() {
+            debug!("Worker update thread knows input is done");
+            done = true;
+            let remote_slots_ref = remote_slots.lock().unwrap();
+            if remote_slots_ref
+                .iter()
+                .find(|worker| worker.update_channel.1.same_channel(&update_receiver))
+                .unwrap()
+                .workers
+                .iter()
+                .filter(|worker| **worker)
+                .count()
+                == 0
+            {
+                debug!("Exiting worker update thread");
+                return;
+            }
+        }
+
+        if let Ok(message) = update_receiver.try_recv() {
+            debug!("Updating worker status: {:?}", message);
+            let mut remote_slots_ref = remote_slots.lock().unwrap();
+            let worker = remote_slots_ref
+                .iter_mut()
+                .find(|worker| worker.update_channel.1.same_channel(&update_receiver))
+                .unwrap();
+            if let Some(status) = message.status {
+                worker.slot_status = status;
+            }
+            if let Some((slot, new_state)) = message.slot_delta {
+                worker.workers[slot] = new_state;
+                if done
+                    && !new_state
+                    && worker.workers.iter().filter(|worker| **worker).count() == 0
+                {
+                    debug!("Exiting worker update thread after receiving message");
+                    return;
+                }
+            }
+            debug!(
+                "Worker now at {:?}, {}/{} workers",
+                worker.slot_status,
+                worker.workers.iter().filter(|worker| **worker).count(),
+                worker.workers.len()
+            );
+        }
+    }
+}
+
+fn listen_for_local_workers<T: Pixel>(
+    encode_opts: EncodeOptions,
+    output_file: &Path,
+    num_segments: &mut usize,
+    thread_pool: &mut ThreadPool,
+    video_info: VideoDetails,
+    progress_channels: &[ProgressChannel],
+    analyzer_receiver: AnalyzerReceiver<T>,
+) -> Result<()> {
+    loop {
+        match analyzer_receiver.try_recv() {
             Ok(Some(data)) => {
-                let slot = data.slot_no;
+                let slot = data.slot;
                 let segment_idx = data.segment_no + 1;
-                num_segments = cmp::max(num_segments, segment_idx);
+                *num_segments = cmp::max(*num_segments, segment_idx);
                 encode_segment(
                     &encode_opts,
                     video_info,
                     data,
-                    &mut thread_pool,
+                    thread_pool,
                     progress_channels[slot].0.clone(),
-                    get_segment_output_filename(&output_file, segment_idx),
+                    get_segment_output_filename(output_file, segment_idx),
                 )?;
             }
             Ok(None) => {
                 // No more input frames, finish.
-                input_finished_channel.0.send(())?;
                 break;
             }
             Err(TryRecvError::Empty) => {
                 sleep(Duration::from_millis(1000));
             }
             Err(e) => {
-                return Err(e.into());
+                debug!("{}", e);
+                break;
             }
         }
     }
-    thread_pool.join();
-
-    mux_output_files(&opts.output, num_segments)?;
-
     Ok(())
+}
+
+fn listen_for_remote_workers(
+    scope: &Scope,
+    remote_analyzer_receiver: RemoteAnalyzerReceiver,
+    input_finished_receiver: InputFinishedReceiver,
+    remote_slots: Arc<Mutex<Vec<RemoteWorkerInfo>>>,
+) {
+    let mut threads = Vec::new();
+    loop {
+        if let Ok(message) = remote_analyzer_receiver.try_recv() {
+            threads.push(scope.spawn(move |_| {
+                if message.video_info.bit_depth <= 8 {
+                    remote_encode_segment::<u8>(message)
+                } else {
+                    remote_encode_segment::<u16>(message)
+                }
+            }));
+        }
+        if input_finished_receiver.is_full()
+            && remote_slots
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|slot| slot.workers.iter())
+                .flatten()
+                .filter(|worker| **worker)
+                .count()
+                == 0
+        {
+            break;
+        }
+        sleep(Duration::from_millis(100));
+    }
+    for thread in threads {
+        thread.join().unwrap();
+    }
 }
 
 fn mux_output_files(out_filename: &Path, num_segments: usize) -> Result<()> {

--- a/rav1e-by-gop/src/bin/remote.rs
+++ b/rav1e-by-gop/src/bin/remote.rs
@@ -1,0 +1,233 @@
+use crate::analyze::SlotReadySender;
+use crate::WorkerConfig;
+use anyhow::{bail, Result};
+use crossbeam_channel::unbounded;
+use http::request::Request;
+use log::{debug, error, warn};
+use rav1e::prelude::Rational;
+use rav1e_by_gop::{
+    create_muxer, ActiveConnection, EncoderMessage, ProgressInfo, ProgressStatus, Slot, SlotStatus,
+    WorkerQueryResponse, WorkerStatusUpdate, WorkerUpdateChannel, WORKER_QUERY_MESSAGE,
+};
+use serde::de::DeserializeOwned;
+use std::collections::BTreeSet;
+use tungstenite::{connect, Error as WsError, Message};
+use url::Url;
+use v_frame::pixel::Pixel;
+
+pub(crate) struct RemoteWorkerInfo {
+    pub uri: Url,
+    pub password: String,
+    // Like local slots, this tracks which workers are active or inactive
+    pub workers: Box<[bool]>,
+    pub slot_status: SlotStatus,
+    pub update_channel: WorkerUpdateChannel,
+}
+
+pub(crate) fn discover_remote_worker(worker: &WorkerConfig) -> Result<RemoteWorkerInfo> {
+    // The http crate has a crap interface for setting the port (i.e. "no interface"),
+    // so do it this kind of stupid way using two crates instead.
+    let mut url = Url::parse(&if worker.secure {
+        format!("wss://{}", worker.host)
+    } else {
+        format!("ws://{}", worker.host)
+    })?;
+    url.set_port(worker.port.or(Some(13415))).unwrap();
+
+    debug!("Initial query to remote worker {}", url);
+    let request = Request::builder()
+        .uri(url.as_str())
+        .header("X-RAV1E-AUTH", &worker.password)
+        .body(())?;
+    let mut connection = connect(request)?.0;
+    connection.write_message(Message::Text(WORKER_QUERY_MESSAGE.to_string()))?;
+
+    // Wait for response
+    let resp;
+    loop {
+        match connection.read_message() {
+            Ok(Message::Binary(data)) => {
+                resp = rmp_serde::from_read::<_, WorkerQueryResponse>(data.as_slice())?;
+                break;
+            }
+            Ok(Message::Close(_)) | Err(_) => {
+                bail!("Connection closed unexpectedly with {}", url);
+            }
+            _ => {
+                // Ignore pings
+            }
+        }
+    }
+
+    // Wait for connection close message
+    loop {
+        match connection.read_message() {
+            Ok(Message::Close(_)) => {
+                break;
+            }
+            Err(e) => {
+                warn!(
+                    "Handshake connection closed unexpectedly with {}: {}",
+                    url, e
+                );
+                // But keep going anyway
+                break;
+            }
+            _ => {
+                // Ignore pings
+            }
+        }
+    }
+
+    Ok(RemoteWorkerInfo {
+        uri: url,
+        password: worker.password.clone(),
+        workers: vec![false; resp.worker_count].into_boxed_slice(),
+        slot_status: SlotStatus::None,
+        update_channel: unbounded(),
+    })
+}
+
+pub(crate) fn wait_for_slot_allocation<T: Pixel + DeserializeOwned + Default>(
+    mut connection: ActiveConnection,
+    slot_ready_sender: SlotReadySender,
+) {
+    loop {
+        debug!("Waiting for slot allocation");
+        match connection.socket.read_message() {
+            Ok(Message::Binary(data)) => {
+                let message: EncoderMessage<T> = match rmp_serde::from_read(data.as_slice()) {
+                    Ok(msg) => msg,
+                    Err(_) => {
+                        continue;
+                    }
+                };
+                if let EncoderMessage::SlotAllocated(connection_id) = message {
+                    debug!("Slot reserved, sending to encoder");
+                    let update_sender = connection.worker_update_sender.clone();
+                    connection.connection_id = Some(connection_id);
+                    let slot_in_worker = connection.slot_in_worker;
+                    if slot_ready_sender
+                        .send(Slot::Remote(Box::new(connection)))
+                        .is_ok()
+                    {
+                        debug!("Slot allocated and sent to encoder");
+                        update_sender
+                            .send(WorkerStatusUpdate {
+                                status: None,
+                                slot_delta: Some((slot_in_worker, true)),
+                            })
+                            .unwrap();
+                    } else {
+                        debug!("Ignoring final slot");
+                    }
+                    return;
+                }
+            }
+            Ok(Message::Close(_))
+            | Err(WsError::ConnectionClosed)
+            | Err(WsError::AlreadyClosed) => {
+                warn!("Connection closed on requesting connection");
+                return;
+            }
+            Err(e) => {
+                error!(
+                    "An unexpected error occurred on requesting connection: {}",
+                    e
+                );
+                return;
+            }
+            _ => {
+                // Ignore message
+            }
+        }
+    }
+}
+
+pub(crate) fn remote_encode_segment<T: Pixel + DeserializeOwned + Default>(
+    mut connection: ActiveConnection,
+) {
+    let encode_info = connection.encode_info.as_ref().unwrap();
+    let video_info = &connection.video_info;
+    let mut output = create_muxer(&encode_info.output_file).unwrap();
+    let mut progress = ProgressInfo::new(
+        Rational {
+            num: video_info.time_base.den,
+            den: video_info.time_base.num,
+        },
+        encode_info.frame_count,
+        {
+            let mut kf = BTreeSet::new();
+            kf.insert(encode_info.start_frameno);
+            kf
+        },
+        encode_info.segment_idx,
+        encode_info.next_analysis_frame,
+    );
+    let _ = connection
+        .progress_sender
+        .send(ProgressStatus::Encoding(Box::new(progress.clone())));
+
+    loop {
+        match connection.socket.read_message() {
+            Ok(Message::Binary(data)) => {
+                let message: EncoderMessage<T> = match rmp_serde::from_read(data.as_slice()) {
+                    Ok(msg) => msg,
+                    Err(_) => {
+                        continue;
+                    }
+                };
+                match message {
+                    EncoderMessage::SendEncodedPacket(packet) => {
+                        output.write_frame(
+                            packet.input_frameno as u64,
+                            packet.data.as_ref(),
+                            packet.frame_type,
+                        );
+                        progress.add_packet(*packet);
+                        let _ = connection
+                            .progress_sender
+                            .send(ProgressStatus::Encoding(Box::new(progress.clone())));
+                    }
+                    EncoderMessage::SegmentFinished => {
+                        debug!("Segment finished normally");
+                        break;
+                    }
+                    EncoderMessage::EncodeFailed(e) => {
+                        error!("VERY BAD YOU SHOULD JUST CTRL+C NOW! Remote encode failed for connection {}: {}", connection.connection_id.unwrap(), e);
+                        break;
+                    }
+                    _ => {
+                        continue;
+                    }
+                }
+            }
+            Ok(Message::Close(_))
+            | Err(WsError::ConnectionClosed)
+            | Err(WsError::AlreadyClosed) => {
+                break;
+            }
+            Err(e) => {
+                error!(
+                    "An unexpected error occurred on connection {} listener: {}",
+                    connection.connection_id.unwrap(),
+                    e
+                );
+                break;
+            }
+            _ => {
+                continue;
+            }
+        }
+    }
+
+    let _ = connection.socket.close(None);
+    output.flush().unwrap();
+    connection
+        .worker_update_sender
+        .send(WorkerStatusUpdate {
+            status: None,
+            slot_delta: Some((connection.slot_in_worker, false)),
+        })
+        .unwrap();
+}

--- a/rav1e-by-gop/src/encode/stats.rs
+++ b/rav1e-by-gop/src/encode/stats.rs
@@ -1,6 +1,7 @@
 use arrayvec::ArrayVec;
 #[cfg(feature = "binary")]
 use console::style;
+#[cfg(feature = "binary")]
 use log::info;
 use rav1e::data::EncoderStats;
 use rav1e::prelude::*;

--- a/rav1e-by-gop/src/lib.rs
+++ b/rav1e-by-gop/src/lib.rs
@@ -1,14 +1,22 @@
 #![allow(clippy::cognitive_complexity)]
 
 use rav1e::prelude::*;
+use serde::{Deserialize, Serialize};
 
 pub mod encode;
 pub mod muxer;
+pub mod remote;
 
 pub use self::encode::*;
 pub use self::muxer::*;
+pub use self::remote::*;
+use crossbeam_channel::{Receiver, Sender};
+use std::path::PathBuf;
+use tungstenite::client::AutoStream;
+use tungstenite::WebSocket;
+use uuid::Uuid;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct VideoDetails {
     pub width: usize,
     pub height: usize,
@@ -31,10 +39,68 @@ impl Default for VideoDetails {
     }
 }
 
+pub enum Slot {
+    Local(usize),
+    Remote(Box<ActiveConnection>),
+}
+
 pub struct SegmentData<T: Pixel> {
     pub segment_no: usize,
-    pub slot_no: usize,
+    pub slot: usize,
     pub next_analysis_frame: usize,
     pub start_frameno: usize,
     pub frames: Vec<Frame<T>>,
+}
+
+pub struct ActiveConnection {
+    pub socket: WebSocket<AutoStream>,
+    pub connection_id: Option<Uuid>,
+    pub slot_in_worker: usize,
+    pub video_info: VideoDetails,
+    pub encode_info: Option<EncodeInfo>,
+    pub worker_update_sender: WorkerUpdateSender,
+    pub progress_sender: ProgressSender,
+}
+
+#[derive(Debug, Clone)]
+pub struct EncodeInfo {
+    pub output_file: PathBuf,
+    pub frame_count: usize,
+    pub next_analysis_frame: usize,
+    pub segment_idx: usize,
+    pub start_frameno: usize,
+}
+
+pub type WorkerUpdateSender = Sender<WorkerStatusUpdate>;
+pub type WorkerUpdateReceiver = Receiver<WorkerStatusUpdate>;
+pub type WorkerUpdateChannel = (WorkerUpdateSender, WorkerUpdateReceiver);
+
+#[derive(Debug, Clone, Copy)]
+pub struct WorkerStatusUpdate {
+    pub status: Option<SlotStatus>,
+    pub slot_delta: Option<(usize, bool)>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SlotStatus {
+    None,
+    Requested,
+}
+
+pub fn build_encoder_config(speed: usize, qp: usize, video_info: VideoDetails) -> Config {
+    let mut enc_config = EncoderConfig::with_speed_preset(speed);
+    enc_config.width = video_info.width;
+    enc_config.height = video_info.height;
+    enc_config.bit_depth = video_info.bit_depth;
+    enc_config.chroma_sampling = video_info.chroma_sampling;
+    enc_config.chroma_sample_position = video_info.chroma_sample_position;
+    enc_config.time_base = video_info.time_base;
+    enc_config.quantizer = qp;
+    enc_config.tiles = 1;
+    enc_config.min_key_frame_interval = 0;
+    enc_config.max_key_frame_interval = u16::max_value() as u64;
+    enc_config.speed_settings.no_scene_detection = true;
+    Config::new()
+        .with_encoder_config(enc_config)
+        .with_threads(1)
 }

--- a/rav1e-by-gop/src/remote/client.rs
+++ b/rav1e-by-gop/src/remote/client.rs
@@ -1,0 +1,75 @@
+use crate::{EncodeOptions, VideoDetails};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use v_frame::frame::Frame;
+use v_frame::pixel::Pixel;
+use zstd::{Decoder, Encoder};
+
+/// The client sends this as a text-based "handshake" to discover
+/// the number of worker threads available in the server.
+pub const WORKER_QUERY_MESSAGE: &str = "handshake";
+
+/// Indicates that the client is requesting a worker slot on the server.
+/// Intended to be a very small message to acquire a slot
+/// before loading frames into memory and sending them over the network.
+///
+/// This is needed to be a separate struct due to needing to know the pixel depth
+/// before receiving an encoder message.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct SlotRequestMessage {
+    pub options: EncodeOptions,
+    pub video_info: VideoDetails,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CompressedRawFrameData {
+    pub connection_id: Uuid,
+    compressed_data: Vec<u8>,
+}
+
+impl CompressedRawFrameData {
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.compressed_data.len()
+    }
+
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.compressed_data.is_empty()
+    }
+}
+
+/// Use this to send y4m frame data, loaded into the v_frame struct,
+/// from the client to the server.
+#[derive(Serialize, Deserialize)]
+pub struct RawFrameData<T: Pixel + Default> {
+    pub connection_id: Uuid,
+    pub frames: Vec<Frame<T>>,
+}
+
+impl<T: Pixel + Default + DeserializeOwned> From<CompressedRawFrameData> for RawFrameData<T> {
+    fn from(compressed: CompressedRawFrameData) -> Self {
+        let decoder = Decoder::new(compressed.compressed_data.as_slice()).unwrap();
+        let frames = bincode::deserialize_from(decoder).unwrap();
+
+        RawFrameData {
+            connection_id: compressed.connection_id,
+            frames,
+        }
+    }
+}
+
+impl<T: Pixel + Default + Serialize> From<RawFrameData<T>> for CompressedRawFrameData {
+    fn from(data: RawFrameData<T>) -> Self {
+        let mut compressed_data = Vec::new();
+        let mut encoder = Encoder::new(&mut compressed_data, 0).unwrap();
+        bincode::serialize_into(&mut encoder, &data.frames).unwrap();
+        encoder.finish().unwrap();
+
+        CompressedRawFrameData {
+            connection_id: data.connection_id,
+            compressed_data,
+        }
+    }
+}

--- a/rav1e-by-gop/src/remote/mod.rs
+++ b/rav1e-by-gop/src/remote/mod.rs
@@ -1,0 +1,5 @@
+pub use client::*;
+pub use server::*;
+
+mod client;
+mod server;

--- a/rav1e-by-gop/src/remote/server.rs
+++ b/rav1e-by-gop/src/remote/server.rs
@@ -1,0 +1,31 @@
+use rav1e::Packet;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use v_frame::pixel::Pixel;
+
+/// The server sends this in response to the handshake message,
+/// then disconnects the handshake connection.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct WorkerQueryResponse {
+    pub worker_count: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum EncoderMessage<T: Pixel + Default> {
+    /// Indicates that the server has allocated a slot for the client
+    /// and is ready to receive data.
+    ///
+    /// Includes the connection ID; the worker will need to send this back
+    /// with each raw frame message.
+    SlotAllocated(Uuid),
+    /// Sends an encoded frame packet from the server to the client.
+    /// Within a segment, these will always be sent in order.
+    SendEncodedPacket(Box<Packet<T>>),
+    /// Indicates that the server is finished encoding the segment,
+    /// and that the slot has been released on the server.
+    /// A new `RequestSlot` message will need to be sent before
+    /// encoding another segment.
+    SegmentFinished,
+    /// We don't want this to happen... It also closes the connection.
+    EncodeFailed(String),
+}

--- a/rav1e-worker/Cargo.toml
+++ b/rav1e-worker/Cargo.toml
@@ -9,10 +9,25 @@ description = "A server to enable distributed encoding with rav1e-by-gop"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 anyhow = "1"
+bincode = "1.2"
+bcrypt = "0.8"
+chrono = "0.4"
 clap = "2"
-ivf = "0.1"
+crossbeam-channel = "0.4"
+crossbeam-utils = "0.7"
+env_logger = "0.7"
+http = "0.2"
+itertools = "0.9"
+lazy_static = "1.4.0"
+log = "0.4"
+native-tls = "0.2"
 num_cpus = "1"
+rav1e = { git = "https://github.com/xiph/rav1e", default-features = false, features = ["asm", "serialize"] }
 rav1e-by-gop = { path = "../rav1e-by-gop", default-features = false }
 rmp-serde = "0.14"
 serde = { version = "1", features = ["derive"] }
-v_frame = "0.1"
+threadpool = "1"
+tungstenite = "0.10"
+uuid = { version = "0.8", features = ["v4", "serde"] }
+v_frame = { version = "0.1", features = ["serialize"] }
+zstd = "0.5"

--- a/rav1e-worker/src/channels.rs
+++ b/rav1e-worker/src/channels.rs
@@ -1,0 +1,6 @@
+use crate::worker::SlotQueueItem;
+use crossbeam_channel::{Receiver, Sender};
+
+pub type SlotRequestSender = Sender<SlotQueueItem>;
+pub type SlotRequestReceiver = Receiver<SlotQueueItem>;
+pub type SlotRequestChannel = (SlotRequestSender, SlotRequestReceiver);

--- a/rav1e-worker/src/main.rs
+++ b/rav1e-worker/src/main.rs
@@ -1,3 +1,77 @@
+use crate::channels::SlotRequestChannel;
+use clap::{App, Arg};
+use crossbeam_channel::unbounded;
+use crossbeam_utils::thread::scope;
+use server::*;
+use std::env;
+use std::net::SocketAddrV4;
+use std::thread::sleep;
+use std::time::Duration;
+use streams::*;
+use worker::*;
+
+mod channels;
+mod server;
+mod streams;
+mod worker;
+
 fn main() {
-    todo!()
+    env::var("SERVER_PASSWORD").expect("SERVER_PASSWORD env var MUST be set!");
+
+    if env::var("RUST_LOG").is_err() {
+        env::set_var("RUST_LOG", "rav1e_worker=info");
+    }
+    env_logger::init();
+
+    let matches = App::new("rav1e-worker")
+        .arg(
+            Arg::with_name("LISTEN_IP")
+                .help("Select which IP to listen on")
+                .long("ip")
+                .visible_alias("host")
+                .default_value("0.0.0.0")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("LISTEN_PORT")
+                .help("Select which port to listen on")
+                .long("port")
+                .short("p")
+                .default_value("13415")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("MAX_THREADS")
+                .help(
+                    "Limit the number of threads that can be used for workers [default: num cpus]",
+                )
+                .long("threads")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let server_ip = SocketAddrV4::new(
+        matches.value_of("LISTEN_IP").unwrap().parse().unwrap(),
+        matches.value_of("LISTEN_PORT").unwrap().parse().unwrap(),
+    );
+    let mut threads = num_cpus::get();
+    if let Some(thread_setting) = matches
+        .value_of("MAX_THREADS")
+        .and_then(|val| val.parse().ok())
+    {
+        threads = threads.min(thread_setting);
+    }
+
+    scope(|scope| {
+        let slot_request_channel: SlotRequestChannel = unbounded();
+        start_listener(server_ip, scope, slot_request_channel.0.clone(), threads)
+            .expect("Server failed to start");
+        start_workers(threads, scope, slot_request_channel.1);
+
+        loop {
+            // Run the thread forever until terminated
+            sleep(Duration::from_secs(60));
+        }
+    })
+    .unwrap();
 }

--- a/rav1e-worker/src/server.rs
+++ b/rav1e-worker/src/server.rs
@@ -1,0 +1,172 @@
+use crate::channels::SlotRequestSender;
+use crate::worker::SlotQueueItem;
+use crate::{ConnectedSocket, SwitchableStream};
+use anyhow::Result;
+use bcrypt::{hash, verify, DEFAULT_COST};
+use crossbeam_utils::thread::Scope;
+use http::StatusCode;
+use lazy_static::lazy_static;
+use log::{debug, error, info, warn};
+use native_tls::{Identity, TlsAcceptor};
+use rav1e_by_gop::{SlotRequestMessage, WorkerQueryResponse, WORKER_QUERY_MESSAGE};
+use std::env;
+use std::fs::File;
+use std::io::Read;
+use std::net::{SocketAddrV4, TcpListener};
+use tungstenite::handshake::server::{ErrorResponse, Request, Response};
+use tungstenite::protocol::WebSocketConfig;
+use tungstenite::server::accept_hdr_with_config;
+use tungstenite::Message;
+
+lazy_static! {
+    static ref HASHED_SERVER_PASSWORD: String =
+        hash(env::var("SERVER_PASSWORD").unwrap(), DEFAULT_COST).unwrap();
+}
+
+pub fn start_listener(
+    server_ip: SocketAddrV4,
+    scope: &Scope,
+    slot_request_sender: SlotRequestSender,
+    worker_threads: usize,
+) -> Result<()> {
+    let server = TcpListener::bind(server_ip)?;
+    let acceptor = if let Ok(identity_file) = env::var("IDENTITY_FILE") {
+        // This is kind of a lot of boilerplate to set up a TLS server...
+        let mut identity_file = File::open(identity_file)?;
+        let mut identity = Vec::new();
+        identity_file.read_to_end(&mut identity)?;
+        let identity = Identity::from_pkcs12(
+            &identity,
+            &env::var("IDENTITY_PASSWORD").unwrap_or_else(|_| String::new()),
+        )?;
+        Some(TlsAcceptor::new(identity).unwrap())
+    } else {
+        None
+    };
+
+    // This thread watches for new incoming connections,
+    // both for the initial negotiation and for new slot requests
+    scope.spawn(move |scope| {
+        info!("Websocket listener started on {}", server_ip);
+
+        for stream in server.incoming() {
+            let stream = match stream {
+                Ok(stream) => stream,
+                Err(e) => {
+                    error!("Failed to receive connection: {}", e);
+                    continue;
+                }
+            };
+            let stream = match acceptor.as_ref() {
+                Some(acceptor) => match acceptor.accept(stream) {
+                    Ok(stream) => SwitchableStream::TlsStream(stream),
+                    Err(e) => {
+                        error!("Failed to accept TLS connection: {}", e);
+                        continue;
+                    }
+                },
+                None => SwitchableStream::TcpStream(stream),
+            };
+            match accept_hdr_with_config(
+                stream,
+                accept_callback,
+                Some(WebSocketConfig {
+                    max_send_queue: None,
+                    max_message_size: None,
+                    max_frame_size: None,
+                }),
+            ) {
+                Ok(stream) => {
+                    let connection = ConnectedSocket::new(stream);
+                    info!("Received new connection {}", connection.id);
+
+                    // Run each connection in its own thread to listen for initial messages,
+                    // since each connection reader is blocking
+                    let slot_request_sender = slot_request_sender.clone();
+                    scope.spawn(move |_| {
+                        initial_connection_listener(connection, worker_threads, slot_request_sender)
+                    });
+                }
+                Err(e) => {
+                    error!("Failed to complete connection handshake: {}", e);
+                    continue;
+                }
+            };
+        }
+    });
+
+    Ok(())
+}
+
+fn initial_connection_listener(
+    mut connection: ConnectedSocket,
+    worker_threads: usize,
+    slot_request_sender: SlotRequestSender,
+) {
+    loop {
+        match connection.socket.read_message() {
+            Ok(Message::Text(data)) => {
+                if data == WORKER_QUERY_MESSAGE {
+                    debug!("Received worker query message from {}", connection.id);
+                    let _ = connection.socket.write_message(Message::Binary(
+                        rmp_serde::to_vec(&WorkerQueryResponse {
+                            worker_count: worker_threads,
+                        })
+                        .unwrap(),
+                    ));
+                    let _ = connection.socket.close(None);
+                    break;
+                } else {
+                    warn!(
+                        "Received unknown text-formatted message for connection {}, ignoring: {}",
+                        connection.id, data
+                    );
+                }
+            }
+            Ok(Message::Binary(data)) => {
+                // Check to see if this is a request message
+                if let Ok(message) = rmp_serde::from_read::<_, SlotRequestMessage>(data.as_slice())
+                {
+                    debug!("Received worker request from {}", connection.id);
+                    slot_request_sender
+                        .send(SlotQueueItem {
+                            connection,
+                            message,
+                        })
+                        .unwrap();
+                    return;
+                } else {
+                    warn!(
+                            "Received unexpected binary-formatted message for connection {} while expecting SlotRequestMessage",
+                            connection.id
+                        );
+                }
+            }
+            Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {
+                // No action needed
+            }
+            Ok(Message::Close(_)) => {
+                info!("Connection {} closed by client", connection.id);
+                return;
+            }
+            Err(e) => {
+                warn!("Connection {} closed unexpectedly: {}", connection.id, e);
+                return;
+            }
+        }
+    }
+}
+
+fn accept_callback(req: &Request, resp: Response) -> std::result::Result<Response, ErrorResponse> {
+    let auth = req.headers().get("X-RAV1E-AUTH");
+    if let Some(password) = auth {
+        if let Ok(password) = password.to_str() {
+            if verify(password, &HASHED_SERVER_PASSWORD).unwrap() {
+                return Ok(resp);
+            }
+        }
+    };
+    let mut resp = ErrorResponse::new(Some("Unauthorized".to_string()));
+    *resp.status_mut() = StatusCode::UNAUTHORIZED;
+    Err(resp)
+}

--- a/rav1e-worker/src/streams.rs
+++ b/rav1e-worker/src/streams.rs
@@ -1,0 +1,51 @@
+use native_tls::TlsStream;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use tungstenite::WebSocket;
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub struct ConnectedSocket {
+    pub id: Uuid,
+    pub socket: WebSocket<SwitchableStream>,
+}
+
+impl ConnectedSocket {
+    pub fn new(socket: WebSocket<SwitchableStream>) -> Self {
+        ConnectedSocket {
+            id: Uuid::new_v4(),
+            socket,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum SwitchableStream {
+    TcpStream(TcpStream),
+    TlsStream(TlsStream<TcpStream>),
+}
+
+impl Read for SwitchableStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            SwitchableStream::TcpStream(stream) => stream.read(buf),
+            SwitchableStream::TlsStream(stream) => stream.read(buf),
+        }
+    }
+}
+
+impl Write for SwitchableStream {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            SwitchableStream::TcpStream(stream) => stream.write(buf),
+            SwitchableStream::TlsStream(stream) => stream.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            SwitchableStream::TcpStream(stream) => stream.flush(),
+            SwitchableStream::TlsStream(stream) => stream.flush(),
+        }
+    }
+}

--- a/rav1e-worker/src/worker.rs
+++ b/rav1e-worker/src/worker.rs
@@ -1,0 +1,217 @@
+use crate::channels::SlotRequestReceiver;
+use crate::ConnectedSocket;
+use crossbeam_utils::thread::Scope;
+use log::{debug, error, info, warn};
+use rav1e::prelude::*;
+use rav1e_by_gop::{
+    build_encoder_config, process_frame, CompressedRawFrameData, EncoderMessage,
+    ProcessFrameResult, RawFrameData, SlotRequestMessage, Source,
+};
+use serde::Serialize;
+use std::cmp;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::thread::sleep;
+use std::time::Duration;
+use threadpool::ThreadPool;
+use tungstenite::Message;
+use v_frame::pixel::Pixel;
+
+#[derive(Debug)]
+pub struct SlotQueueItem {
+    pub connection: ConnectedSocket,
+    pub message: SlotRequestMessage,
+}
+
+pub fn start_workers(
+    worker_threads: usize,
+    scope: &Scope,
+    slot_request_receiver: SlotRequestReceiver,
+) {
+    info!("Starting {} workers", worker_threads);
+    let thread_pool = ThreadPool::new(worker_threads);
+    let slot_request_queue: Arc<Mutex<VecDeque<SlotQueueItem>>> =
+        Arc::new(Mutex::new(VecDeque::new()));
+
+    // This thread watches the slot request receiver
+    // for new slot requests
+    let slot_request_queue_handle = slot_request_queue.clone();
+    scope.spawn(move |_| {
+        while let Ok(message) = slot_request_receiver.recv() {
+            slot_request_queue_handle.lock().unwrap().push_back(message);
+        }
+    });
+
+    // This thread watches the slot request queue
+    // and allocates slots when they are available.
+    let slot_request_queue_handle = slot_request_queue;
+    scope.spawn(move |_| loop {
+        sleep(Duration::from_secs(1));
+
+        let active_workers = thread_pool.active_count();
+        let total_workers = thread_pool.max_count();
+        if active_workers >= total_workers {
+            continue;
+        }
+
+        let mut queue = slot_request_queue_handle.lock().unwrap();
+        let total_items = queue.len();
+        let ready_items = queue
+            .drain(0..cmp::min(total_items, total_workers - active_workers))
+            .collect::<Vec<_>>();
+        debug!(
+            "Slot queue: {} total items, {} slots available",
+            total_items,
+            ready_items.len()
+        );
+        for queue_item in ready_items {
+            info!(
+                "Notifying client {} that a slot is ready",
+                queue_item.connection.id
+            );
+
+            let slot_request = queue_item.message;
+            let mut connection = queue_item.connection;
+            let _ = connection.socket.write_message(Message::Binary(
+                if slot_request.video_info.bit_depth <= 8 {
+                    rmp_serde::to_vec(&EncoderMessage::SlotAllocated::<u8>(connection.id)).unwrap()
+                } else {
+                    rmp_serde::to_vec(&EncoderMessage::SlotAllocated::<u16>(connection.id)).unwrap()
+                },
+            ));
+
+            thread_pool.execute(move || wait_for_remote_data(connection, slot_request));
+        }
+    });
+}
+
+pub fn encode_segment<T: Pixel + Default + Serialize>(
+    mut connection: ConnectedSocket,
+    encode_request: SlotRequestMessage,
+    input: RawFrameData<T>,
+) {
+    let connection_id = input.connection_id;
+    let frames = input.frames.into_iter().map(Arc::new).collect::<Vec<_>>();
+    if !frames.is_empty() {
+        let cfg = build_encoder_config(
+            encode_request.options.speed,
+            encode_request.options.qp,
+            encode_request.video_info,
+        );
+
+        let mut ctx: Context<T> = match cfg.new_context() {
+            Ok(ctx) => ctx,
+            Err(e) => {
+                error!(
+                    "Failed to create encode context for connection {}: {}",
+                    connection_id, e
+                );
+                let _ = connection.socket.write_message(Message::Binary(
+                    rmp_serde::to_vec(&EncoderMessage::<T>::EncodeFailed(e.to_string())).unwrap(),
+                ));
+                let _ = connection.socket.close(None);
+                return;
+            }
+        };
+        let mut source = Source {
+            frames,
+            sent_count: 0,
+        };
+        loop {
+            match process_frame(&mut ctx, &mut source) {
+                Ok(ProcessFrameResult::Packet(packet)) => {
+                    debug!(
+                        "Sending frame {} to {}",
+                        packet.input_frameno, connection_id
+                    );
+                    if let Err(e) = connection.socket.write_message(Message::Binary(
+                        rmp_serde::to_vec(&EncoderMessage::<T>::SendEncodedPacket(packet)).unwrap(),
+                    )) {
+                        error!(
+                            "Failed to send packet for connection {}: {}",
+                            connection_id, e
+                        );
+                        let _ = connection.socket.write_message(Message::Binary(
+                            rmp_serde::to_vec(&EncoderMessage::<T>::EncodeFailed(e.to_string()))
+                                .unwrap(),
+                        ));
+                        let _ = connection.socket.close(None);
+                        return;
+                    };
+                }
+                Ok(ProcessFrameResult::NoPacket) => {
+                    // Next iteration
+                }
+                Ok(ProcessFrameResult::EndOfSegment) => {
+                    break;
+                }
+                Err(e) => {
+                    error!("Encoding error for connection {}: {}", connection_id, e);
+                    let _ = connection.socket.write_message(Message::Binary(
+                        rmp_serde::to_vec(&EncoderMessage::<T>::EncodeFailed(e.to_string()))
+                            .unwrap(),
+                    ));
+                    let _ = connection.socket.close(None);
+                    return;
+                }
+            };
+        }
+    }
+
+    info!("Sending segment finished message to {}", connection_id);
+    if let Err(e) = connection.socket.write_message(Message::Binary(
+        rmp_serde::to_vec(&EncoderMessage::<T>::SegmentFinished).unwrap(),
+    )) {
+        error!(
+            "Failed to write segment finished message for connection {}: {}",
+            connection_id, e
+        );
+    };
+    if let Err(e) = connection.socket.close(None) {
+        error!("Failed to close connection {}: {}", connection_id, e);
+    };
+}
+
+fn wait_for_remote_data(mut connection: ConnectedSocket, slot_request: SlotRequestMessage) {
+    loop {
+        match connection.socket.read_message() {
+            Ok(Message::Binary(data)) => {
+                // This must be an encoder message, start the encode
+                if let Ok(data) = rmp_serde::from_read::<_, CompressedRawFrameData>(data.as_slice())
+                {
+                    if slot_request.video_info.bit_depth <= 8 {
+                        let input = RawFrameData::<u8>::from(data);
+                        info!(
+                            "Received {} raw frames from {}",
+                            input.frames.len(),
+                            connection.id
+                        );
+                        encode_segment(connection, slot_request, input);
+                    } else {
+                        let input = RawFrameData::<u16>::from(data);
+                        info!(
+                            "Received {} raw frames from {}",
+                            input.frames.len(),
+                            connection.id
+                        );
+                        encode_segment(connection, slot_request, input);
+                    }
+                    return;
+                } else {
+                    error!("Failed to read frame data for connection {}", connection.id);
+                }
+            }
+            Ok(Message::Text(_)) | Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {
+                // No action needed
+            }
+            Ok(Message::Close(_)) => {
+                info!("Connection {} closed by client", connection.id);
+                return;
+            }
+            Err(e) => {
+                warn!("Connection {} closed unexpectedly: {}", connection.id, e);
+                return;
+            }
+        }
+    }
+}

--- a/workers.example.toml
+++ b/workers.example.toml
@@ -1,0 +1,21 @@
+# Each worker will begin with the `[[workers]]` key
+[[workers]]
+# `host` is required, for obvious reasons
+host = "192.168.1.101"
+# `port` is optional, and will use the default server port if not specified
+port = 9000
+# `password` is required; it should match the server password
+password = "Friendly-Influence-Warm-Notice-6"
+
+[[workers]]
+# IPv6 also works
+host = "2001:db8::8a2e:370:7334"
+password = "Reasonable-Speak-Bear-Hammer-9"
+
+[[workers]]
+# A domain name will work also
+host = "worker-1.mydomain.com"
+password = "Interfere-Customer-Cut-Landlord-2"
+# Recommended, but requires the server be configured
+# with a valid TLS certificate
+secure = true


### PR DESCRIPTION
Adds rav1e-worker, which acts as a server on a remote encoding machine and listens to connections from clients. The client, part of rav1e-by-gop, negotiates with the server, the server notifies the client as it has slots available, and the client sends one segment at a time to the server. The server can have multiple worker threads, and a client can use as many threads as the server will allow. A server can also serve multiple clients at once, which it does via a FIFO queue. The queue only holds slot requests, so the client does not send frames until the server signals a slot is ready. The client will send to the first worker that signals a slot is available. This keeps memory usage down on both the client and server, and streamlines the threading process so the end of an encode is not stalled waiting for a specific remote worker, if there are other workers or local threads available.

Communication is done using websockets, and is insecure by default, but can be configured to use TLS. Unfortunately this does not currently work with self-signed certs. Client-server authentication is done using a simple password system; a password is configured on the server, and then the client must be configured to use the same password for this server.

The frame sending process is quite upload-heavy. The input frames are sent xz-compressed to try and alleviate this, however results will still be best if workers are on a LAN or other connection with a fast upload. I found that even with a 10Mbps upload from my home connection, the remote workers still were more than efficient enough to be worth using.

Closes #10